### PR TITLE
Hierophant Club can no longer becomes ash

### DIFF
--- a/code/modules/mining/lavaland/loot/hierophant_loot.dm
+++ b/code/modules/mining/lavaland/loot/hierophant_loot.dm
@@ -16,6 +16,7 @@
 	attack_verb = list("clubbed", "beat", "pummeled")
 	hitsound = 'sound/weapons/sonic_jackhammer.ogg'
 	actions_types = list(/datum/action/item_action/vortex_recall, /datum/action/item_action/toggle_unfriendly_fire)
+	resistance_flags = LAVA_PROOF | FIRE_PROOF
 	var/cooldown_time = 20 //how long the cooldown between non-melee ranged attacks is
 	var/chaser_cooldown = 81 //how long the cooldown between firing chasers at mobs is
 	var/chaser_timer = 0 //what our current chaser cooldown is


### PR DESCRIPTION
## What Does This PR Do
Stops the Hierophant Club from turning to ash.

## Why It's Good For The Game
So when an ash drake desides to sneeze in your general direction the club doesn't turn to ash. The club is basically the body of the dead boss,(I know that the old sprite was the boss holding the club, but with the current sprite, the club itself is the boss) so it doesn't make much sense for the club to be turned to ash so easily, even more so that the boss literally lives on lavaland.

## Images of changes
N/A

## Testing
(My VSCode is borked, Funnyman will be testing it for me)

## Changelog
:cl:
tweak: Gives the Hierophant Club the resistance flags LAVA_PROOF and FIRE_PROOF.
/:cl:
